### PR TITLE
Persist state via URL

### DIFF
--- a/src/components/GameStateSync.tsx
+++ b/src/components/GameStateSync.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import useGameStore from '../store/gameStore';
+import { decodeGameState, encodeGameState, copyCurrentStateUrl } from '../utils/urlState';
+
+export default function GameStateSync() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const encoded = params.get('state');
+    if (encoded) {
+      const state = decodeGameState(encoded);
+      if (state) {
+        useGameStore.setState(state);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const unsub = useGameStore.subscribe((newState) => {
+      const encoded = encodeGameState(newState);
+      const params = new URLSearchParams();
+      params.set('state', encoded);
+      window.history.replaceState(null, '', `#${params.toString()}`);
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <div className="mb-4 text-right">
+      <button
+        onClick={copyCurrentStateUrl}
+        className="px-3 py-1 bg-indigo-600 rounded text-white hover:bg-indigo-700"
+      >
+        Copy Game Link
+      </button>
+    </div>
+  );
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,10 +2,12 @@
 import Layout from '../layouts/Layout.astro';
 import ScoreInput from '../components/ScoreInput';
 import ScoreBoard from '../components/ScoreBoard';
+import GameStateSync from '../components/GameStateSync';
 ---
 
 <Layout title="Hand and Foot Scorer">
   <main class="container mx-auto px-4 py-8">
+    <GameStateSync client:load />
     <h1 class="text-4xl font-bold text-center text-white mb-8">Hand and Foot Scorer</h1>
     <p class="text-center text-gray-300 mb-8">
       The hand contains 11 cards and the foot contains 15 cards. Don't forget your foot soldier!

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -1,0 +1,113 @@
+import type { GameState } from '../types/game';
+import useGameStore from '../store/gameStore';
+
+// FNV-1a 32bit hash
+function fnv1a(str: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+// Simple LZW compression returning base64 string
+function lzwCompress(str: string): string {
+  const dict = new Map<string, number>();
+  for (let i = 0; i < 256; i++) {
+    dict.set(String.fromCharCode(i), i);
+  }
+  let dictSize = 256;
+  let w = '';
+  const result: number[] = [];
+  for (const c of str) {
+    const wc = w + c;
+    if (dict.has(wc)) {
+      w = wc;
+    } else {
+      result.push(dict.get(w)!);
+      dict.set(wc, dictSize++);
+      w = c;
+    }
+  }
+  if (w !== '') result.push(dict.get(w)!);
+  const bytes: number[] = [];
+  for (const code of result) {
+    bytes.push(code >> 8, code & 0xff);
+  }
+  return encodeURIComponent(btoa(String.fromCharCode(...bytes)));
+}
+
+function lzwDecompress(data: string): string | null {
+  try {
+    const decoded = atob(decodeURIComponent(data));
+    const bytes = Array.from(decoded, (c) => c.charCodeAt(0));
+    const codes: number[] = [];
+    for (let i = 0; i < bytes.length; i += 2) {
+      codes.push((bytes[i] << 8) | bytes[i + 1]);
+    }
+    const dict = new Map<number, string>();
+    for (let i = 0; i < 256; i++) {
+      dict.set(i, String.fromCharCode(i));
+    }
+    let dictSize = 256;
+    let w = String.fromCharCode(codes[0]);
+    let result = w;
+    for (let i = 1; i < codes.length; i++) {
+      const k = codes[i];
+      let entry: string;
+      if (dict.has(k)) {
+        entry = dict.get(k)!;
+      } else if (k === dictSize) {
+        entry = w + w[0];
+      } else {
+        return null;
+      }
+      result += entry;
+      dict.set(dictSize++, w + entry[0]);
+      w = entry;
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+export function encodeGameState(state: GameState): string {
+  const json = JSON.stringify(state, (_key, value) =>
+    value instanceof Set ? Array.from(value) : value
+  );
+  const compressed = lzwCompress(json);
+  const hash = fnv1a(json).toString(16);
+  return `${hash}-${compressed}`;
+}
+
+export function decodeGameState(value: string): GameState | null {
+  const index = value.indexOf('-');
+  if (index === -1) return null;
+  const hash = value.slice(0, index);
+  const compressed = value.slice(index + 1);
+  const json = lzwDecompress(compressed);
+  if (!json) return null;
+  if (fnv1a(json).toString(16) !== hash) return null;
+  try {
+    const parsed = JSON.parse(json) as GameState & { completedRounds: string[] };
+    if (Array.isArray(parsed.completedRounds)) {
+      parsed.completedRounds = new Set(parsed.completedRounds);
+    } else {
+      parsed.completedRounds = new Set();
+    }
+    return parsed as GameState;
+  } catch {
+    return null;
+  }
+}
+
+export function copyCurrentStateUrl() {
+  const state = useGameStore.getState();
+  const encoded = encodeGameState(state);
+  const params = new URLSearchParams();
+  params.set('state', encoded);
+  const url = `${window.location.origin}${window.location.pathname}#${params.toString()}`;
+  navigator.clipboard.writeText(url);
+}


### PR DESCRIPTION
## Summary
- add utils for encoding game state in the URL
- sync store state with the URL using GameStateSync component
- expose 'Copy Game Link' button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68411ffdae1c832e8cdaee4a07f3202c