### PR TITLE
Update documentation for Hand and Foot app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,54 @@
-# Astro Starter Kit: Basics
+# Hand and Foot Scorer
 
-```sh
-npm create astro@latest -- --template basics
-```
+A small web app for tracking scores in the card game **Hand and Foot**. It is built with [Astro](https://astro.build/), React and Tailwind CSS.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
+The application lets two teams record their points across four rounds, automatically calculating bonuses and penalties. You can share the current game state via the **Copy Game Link** button, which encodes the match data into the URL hash.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Installation
 
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
+1. Install dependencies using npm:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The site will be available at `http://localhost:4321`.
 
-## 🚀 Project Structure
+For a production build run `npm run build` and preview it with `npm run preview`.
 
-Inside of your Astro project, you'll see the following folders and files:
+## How to Play and Score
 
-```text
-/
-├── public/
-│   └── favicon.svg
-├── src/
-│   ├── components/
-│   │   └── Card.astro
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
+Hand and Foot is played in four rounds with increasing meld requirements of 50, 90, 120 and 150 points. Each team has a **hand** of 11 cards and a **foot** of 15 cards. Books consist of seven cards of the same rank.
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+The scoring categories used in this app are:
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+### Books
+- **Red (clean)** &ndash; 500 points
+- **Black (dirty)** &ndash; 300 points
+- **Sevens** &ndash; 5000 points
+- **Fives** &ndash; 3000 points
+- **Wilds** &ndash; 2500 points
 
-Any static assets, like images, can be placed in the `public/` directory.
+### Card Points
+Enter the total value of all melded cards. Card values are:
+- Jokers: 50 points
+- Aces and 2s: 20 points
+- 8 through King: 10 points
+- 4 through 7: 5 points
 
-## 🧞 Commands
+### Penalties
+- Black 3s left in hand/foot: **-100** each
+- Red 3s left in hand/foot: **-500** each
+- Points from any remaining cards are subtracted from the score
 
-All commands are run from the root of the project, from a terminal:
+### Bonuses
+- Going out: **+100** points
+- Red 3s collected: **+100** each
+- Collecting all seven red 3s gives an extra **+300** points
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+At the end of each round the total is computed from the values above. The team with the highest cumulative score after all rounds wins.
 
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+---
+Licensed under the MIT License. See `LICENSE` for details.


### PR DESCRIPTION
## Summary
- replace default Astro README with instructions for the Hand and Foot scoring application

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68412d516c44832ebdf9df642ebbc562