### PR TITLE
Add unit tests for game store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+
+build
+
+dist

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "rm -rf build && npx esbuild src/store/gameStore.ts --outfile=build/store/gameStore.js --format=esm --platform=node && node --test"
   },
   "dependencies": {
     "astro": "^4.15.11",

--- a/test/gameStore.test.js
+++ b/test/gameStore.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert';
+import { test, beforeEach } from 'node:test';
+import useGameStore, { updateRoundScore, updateTeamName, addCompletedRound } from '../build/store/gameStore.js';
+
+const initialRoundScore = () => ({
+  books: { red: 0, black: 0, sevens: 0, fives: 0, wilds: 0 },
+  meldedCards: 0,
+  penalties: { blackThrees: 0, redThrees: 0, remainingCards: 0 },
+  bonuses: { goingOut: false, redThrees: 0 },
+  totalScore: 0,
+});
+
+const initialState = {
+  teams: [
+    { id: 1, name: 'Team 1', players: [] },
+    { id: 2, name: 'Team 2', players: [] }
+  ],
+  currentRound: 1,
+  scores: [
+    { teamId: 1, rounds: Array.from({ length: 4 }, () => initialRoundScore()), totalScore: 0 },
+    { teamId: 2, rounds: Array.from({ length: 4 }, () => initialRoundScore()), totalScore: 0 }
+  ],
+  meldRequirements: [50, 90, 120, 150],
+  completedRounds: new Set(),
+};
+
+beforeEach(() => {
+  useGameStore.setState(initialState, true);
+});
+
+test('updateRoundScore calculates totals correctly', () => {
+  const round = {
+    books: { red: 1, black: 1, sevens: 0, fives: 0, wilds: 0 },
+    meldedCards: 0,
+    penalties: { blackThrees: 1, redThrees: 0, remainingCards: 0 },
+    bonuses: { goingOut: false, redThrees: 2 },
+    totalScore: 0,
+  };
+
+  updateRoundScore(1, 0, round, 100);
+  const state = useGameStore.getState();
+  const score = state.scores[0].rounds[0].totalScore;
+  const teamTotal = state.scores[0].totalScore;
+  assert.equal(score, 1000);
+  assert.equal(teamTotal, 1000);
+});
+
+test('updateTeamName changes the team name', () => {
+  updateTeamName(1, 'Winners');
+  assert.equal(useGameStore.getState().teams[0].name, 'Winners');
+});
+
+test('addCompletedRound marks a round as completed', () => {
+  addCompletedRound(2, 3);
+  assert.ok(useGameStore.getState().completedRounds.has('2-3'));
+});


### PR DESCRIPTION
## Summary
- ignore build and dist folders
- add test script using Node's built-in test runner
- create unit tests for game store logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684122d81f90832ebcafe0b835d12102