### PR TITLE
Enable editing submitted rounds

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { GameState, Team, TeamScore, RoundScore } from '../types/game';
 
-const calculateRoundScore = (round: RoundScore, meldedPoints: number): number => {
+const calculateRoundScore = (round: RoundScore): number => {
   const bookPoints = 
     round.books.red * 500 +
     round.books.black * 300 +
@@ -19,7 +19,7 @@ const calculateRoundScore = (round: RoundScore, meldedPoints: number): number =>
     (round.bonuses.redThrees * 100) +
     (round.bonuses.redThrees >= 7 ? 300 : 0);
 
-  return bookPoints + meldedPoints + penaltyPoints + bonusPoints;
+  return bookPoints + round.meldedCards + penaltyPoints + bonusPoints;
 };
 
 const initialRoundScore = (): RoundScore => ({
@@ -71,14 +71,21 @@ export const addCompletedRound = (teamId: number, roundIndex: number) =>
     completedRounds: new Set([...state.completedRounds, `${teamId}-${roundIndex}`])
   }));
 
-export const updateRoundScore = (teamId: number, roundIndex: number, score: RoundScore, meldedPoints: number) =>
+export const removeCompletedRound = (teamId: number, roundIndex: number) =>
+  useGameStore.setState((state) => {
+    const updated = new Set(state.completedRounds);
+    updated.delete(`${teamId}-${roundIndex}`);
+    return { completedRounds: updated };
+  });
+
+export const updateRoundScore = (teamId: number, roundIndex: number, score: RoundScore) =>
   useGameStore.setState((state) => {
     const newScores = state.scores.map((teamScore) => {
       if (teamScore.teamId === teamId) {
         const newRounds = [...teamScore.rounds];
         newRounds[roundIndex] = {
           ...score,
-          totalScore: calculateRoundScore(score, meldedPoints),
+          totalScore: calculateRoundScore(score),
         };
         return {
           ...teamScore,

--- a/test/gameStore.test.js
+++ b/test/gameStore.test.js
@@ -31,13 +31,13 @@ beforeEach(() => {
 test('updateRoundScore calculates totals correctly', () => {
   const round = {
     books: { red: 1, black: 1, sevens: 0, fives: 0, wilds: 0 },
-    meldedCards: 0,
+    meldedCards: 100,
     penalties: { blackThrees: 1, redThrees: 0, remainingCards: 0 },
     bonuses: { goingOut: false, redThrees: 2 },
     totalScore: 0,
   };
 
-  updateRoundScore(1, 0, round, 100);
+  updateRoundScore(1, 0, round);
   const state = useGameStore.getState();
   const score = state.scores[0].rounds[0].totalScore;
   const teamTotal = state.scores[0].totalScore;


### PR DESCRIPTION
## Summary
- keep round inputs after submitting
- make submitted rounds read-only and add an Edit option
- store melded card points in the game store
- update tests for new store behavior

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a3ab6e82c832e8c9b31890bb51349